### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.vscode
-Content/obj/DesktopGL/net6.0/Content/.mgstats
-bin/*
-obj/Debug/*
+.vs*
+Content/bin
+Content/obj
+bin
+obj


### PR DESCRIPTION
- Apply generally to bin and obj for root and Content
- Wildcard directories for both Visual Studio Community and VSCode